### PR TITLE
Safari browser - issues with .startsWith function

### DIFF
--- a/src/roundslider.js
+++ b/src/roundslider.js
@@ -1099,7 +1099,7 @@
             }
             else if (typeof options === "string") {
                 if (typeof instance[options] === "function") {
-                    if ((options == "option" || options.startsWith("get")) && args[2] === undefined) {
+                    if ((options === "option" || (typeof options.startsWith === 'function' && options.startsWith("get"))) && args[2] === undefined) {
                         return instance[options](args[1]);
                     }
                     instance[options](args[1], args[2]);


### PR DESCRIPTION
In Safari, call to options.startsWith("get") throw an error if startsWith is not defined as a function
