### PR TITLE
Raise change event when setValue is used

### DIFF
--- a/src/roundslider.js
+++ b/src/roundslider.js
@@ -1096,6 +1096,7 @@
                     else if (this.options.sliderType == "default") this._active = index;
                 }
                 this._set("value", value);
+                this._raise("change");
             }
         },
         disable: function () {


### PR DESCRIPTION
If you have a input fields and set the min/max values manually with the setValue method, the change event wasn't raised.

This change makes it happen, and just allows me to use the change hook that I already attached to the slider.

I didn't include a minified version of the change, I wasn't sure if what tool you used for the minification.  If  you let me know, I'll make a change to the patch.

Thanks!
