### PR TITLE
Replaced instances of eval with parseFloat

### DIFF
--- a/src/roundslider.js
+++ b/src/roundslider.js
@@ -428,7 +428,7 @@
             var o = this.options, hSize = o.handleSize, width = o.width, h, w, isSquare = true, isNumber = this.isNumber;
             if (typeof hSize === "string" && isNumber(hSize)) {
                 if (hSize.charAt(0) === "+" || hSize.charAt(0) === "-") {
-                    try { hSize = eval(width + hSize.charAt(0) + Math.abs(parseFloat(hSize))); }
+                    try { hSize = width + parseFloat(hSize.charAt(0) + Math.abs(parseFloat(hSize))); }
                     catch (e) { console.warn(e); }
                 }
                 else if (hSize.indexOf(",")) {
@@ -1028,7 +1028,7 @@
         _validateEndAngle: function () {
             var o = this.options, start = o.startAngle, end = o.endAngle;
             if (typeof end === "string" && this.isNumber(end) && (end.charAt(0) === "+" || end.charAt(0) === "-")) {
-                try { end = eval(start + end.charAt(0) + Math.abs(parseFloat(end))); }
+                try { end = start + parseFloat(end.charAt(0) + Math.abs(parseFloat(end))); }
                 catch (e) { console.warn(e); }
             }
             end = (this.isNumber(end) ? parseFloat(end) : 360) % 360;


### PR DESCRIPTION
I'm using this library in a project where the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is not allowed to contain `unsafe-eval`, so I investigated why this library needs to call `eval` and modified the two offending lines to use `parseFloat` instead, which is safer from a security point of view.

The `eval` lines were evaluating simple math expressions from a string such as `eval("90+360")` or `eval("45-180")`, so I modified it to instead add the first number with a parsed float from the sign and the second number. The previous examples would be evaluated as `90 + parseFloat("+360")` and `45 + parseFloat("-180")` respectively with the new method.